### PR TITLE
Set first read then

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+.idea/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/src/main/java/org/akirathan/chdir/Main.java
+++ b/src/main/java/org/akirathan/chdir/Main.java
@@ -5,12 +5,12 @@ import java.io.File;
 public class Main {
 
   public static void main(String[] args) {
-    printCurWorkingDir();
-    System.out.println("=== Changing working directory to /tmp ===");
-
-    var linuxApi = new LinuxWorkingDirectory();
-    linuxApi.changeWorkingDir("/tmp");
-    System.setProperty("user.dir", "/tmp");
+    if (args.length != 1) {
+      System.err.println("Usage: provide argument with path to CWD to");
+    } else {
+      var linuxApi = new LinuxWorkingDirectory();
+      linuxApi.changeWorkingDir(args[0]);
+    }
     printCurWorkingDir();
   }
 


### PR DESCRIPTION
Applying patch suggested by @JaroslavTulach in https://github.com/Akirathan/chdir-native/issues/1#issue-2958667758. i.e., when `java.io` filesystem is accessed **after** `chdir` syscall, it works as expected.