### PR TITLE
Detect project root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,11 @@
   </properties>
 
   <dependencies>
-
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.9.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/org/akirathan/chdir/Main.java
+++ b/src/main/java/org/akirathan/chdir/Main.java
@@ -1,11 +1,20 @@
 package org.akirathan.chdir;
 
 import java.io.File;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 public class Main {
+  private static final Option CWD =
+      new Option("cwd", true, "Path to change directory to");
+  private static final Options OPTIONS =
+      new Options().addOption(CWD);
 
-  public static void main(String[] args) {
-    if (args.length != 1) {
+  public static void main(String[] args) throws ParseException {
+    var line = new DefaultParser().parse(OPTIONS, args);
+    if (!line.hasOption(CWD)) {
       System.err.println("Usage: provide argument with path to CWD to");
     } else {
       var linuxApi = new LinuxWorkingDirectory();

--- a/src/main/java/org/akirathan/chdir/Main.java
+++ b/src/main/java/org/akirathan/chdir/Main.java
@@ -9,7 +9,19 @@ public class Main {
       System.err.println("Usage: provide argument with path to CWD to");
     } else {
       var linuxApi = new LinuxWorkingDirectory();
-      linuxApi.changeWorkingDir(args[0]);
+      var dir = line.getOptionValue(CWD);
+      while (dir != null) {
+        if (linuxApi.exists(dir, "package.yaml")) {
+          linuxApi.changeWorkingDir(dir);
+          break;
+        }
+        var lastSlash = dir.lastIndexOf('/');
+        if (lastSlash == -1) {
+          dir = null;
+        } else {
+          dir = dir.substring(0, lastSlash);
+        }
+      }
     }
     printCurWorkingDir();
   }


### PR DESCRIPTION
Add Apache Commons CLI and check directory existance with `access` syscall. This mimicks the behavior of github.com/enso-org/enso cmdline launcher.

Patch applied from https://github.com/Akirathan/chdir-native/issues/1#issuecomment-2764401481

```
$ ./target/chdir-native -cwd ~/dev/enso/test/Base_Tests/src/Data/Vector_Spec.enso
user.dir system prop = /home/pavel/dev/enso/test/Base_Tests
pwd = /home/pavel/dev/enso/test/Base_Tests
getcwd = /home/pavel/dev/enso/test/Base_Tests
new File("MY_FILE.txt").getAbsolutePath() = /home/pavel/dev/enso/test/Base_Tests/MY_FILE.txt
```